### PR TITLE
Fetch otdrs from crates.io and add tauri to package.json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,31 +1,32 @@
 {
-  "name": "otdr-viewer",
-  "private": true,
-  "version": "0.0.0",
-  "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "build": "vue-tsc --noEmit && vite build",
-    "preview": "vite preview"
-  },
-  "dependencies": {
-    "@popperjs/core": "^2.11.5",
-    "@tauri-apps/api": "^1.0.2",
-    "bootstrap": "^5.2.0",
-    "echarts": "^5.3.3",
-    "luxon": "^3.0.1",
-    "pinia": "^2.0.16",
-    "sass": "^1.53.0",
-    "vue": "^3.2.37",
-    "vue-echarts": "^6.2.3",
-    "vue-router": "^4.1.2"
-  },
-  "devDependencies": {
-    "@tauri-apps/cli": "^1.0.5",
-    "@types/luxon": "^3.0.0",
-    "@vitejs/plugin-vue": "^3.0.0",
-    "typescript": "^4.6.4",
-    "vite": "^3.0.0",
-    "vue-tsc": "^0.38.4"
-  }
+    "name": "otdr-viewer",
+    "private": true,
+    "version": "0.0.0",
+    "type": "module",
+    "scripts": {
+        "dev": "vite",
+        "build": "vue-tsc --noEmit && vite build",
+        "preview": "vite preview",
+        "tauri": "tauri"
+    },
+    "dependencies": {
+        "@popperjs/core": "^2.11.5",
+        "@tauri-apps/api": "^1.0.2",
+        "bootstrap": "^5.2.0",
+        "echarts": "^5.3.3",
+        "luxon": "^3.0.1",
+        "pinia": "^2.0.16",
+        "sass": "^1.53.0",
+        "vue": "^3.2.37",
+        "vue-echarts": "^6.2.3",
+        "vue-router": "^4.1.2"
+    },
+    "devDependencies": {
+        "@tauri-apps/cli": "^1.0.5",
+        "@types/luxon": "^3.0.0",
+        "@vitejs/plugin-vue": "^3.0.0",
+        "typescript": "^4.6.4",
+        "vite": "^3.0.0",
+        "vue-tsc": "^0.38.4"
+    }
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1735,6 +1735,8 @@ checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 [[package]]
 name = "otdrs"
 version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "551f7c8ca45cd96337e5e0b6648ead00321f623c028886dd9fa9bd0666e9dde7"
 dependencies = [
  "clap",
  "crc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ tauri-build = { version = "1.0.4", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.0.4", features = ["dialog-all"] }
-otdrs = { path = "../../otdr/otdrs" }
+otdrs = { version = "1.0.0" }
 tauri-plugin-window-state = "0.1"
 # ndarray = { version = "0.15.6", features = ["rayon", "serde"] }
 rayon = "1.5"


### PR DESCRIPTION
Hi there.

Thanks for this simple viewer.

Since `otdrs` is plublished on crates.io (in v1.0.0) I thought it would be easier to hack around if it fetches otdrs from crates.io.

I also added `tauri` to `package.json`. Running `npm run tauri build` worked perfectly for me.